### PR TITLE
旅行データのローディング方法の変更

### DIFF
--- a/manuals.md
+++ b/manuals.md
@@ -22,6 +22,8 @@ bun shadcn-ui init
 bun shadcn-ui add button
 bun shadcn-ui add form
 bun shadcn-ui add input
+bun shadcn-ui add card
+bun shadcn-ui add skeleton
 ```
 
 # Supabaseの型収集

--- a/src/__tests__/Components/projects/project-detail/travel-list/molecules/travel-card.test.tsx
+++ b/src/__tests__/Components/projects/project-detail/travel-list/molecules/travel-card.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, cleanup  } from '@testing-library/react';
+import { describe, test, expect, afterEach } from "bun:test";
+import { Travel } from "@prisma/client";
+import TravelCard from '@/app/Components/projects/project-detail/travel-list/molecules/travel-card';
+
+describe('TravelCard', () => {
+    const travel: Travel = {
+        id: "1",
+        name: "Tokyo Trip",
+        description: "A wonderful trip to Tokyo",
+        amount: 10000,
+        date: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        userId: "user1",
+        projectId: "project1",
+        categoryId: "category1",
+    };
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    test("should render travel name", () => {
+        render(<TravelCard travel={travel} />);
+        expect(screen.queryByText(travel.name)).not.toBeNull();
+    });
+
+    test("should render travel description", () => {
+        render(<TravelCard travel={travel} />);
+        expect(screen.queryByText(travel.description as string)).not.toBeNull();
+    });
+
+    test("should render travel amount", () => {
+        render(<TravelCard travel={travel} />);
+        expect(screen.queryByText(`金額: ${travel.amount}円`)).not.toBeNull();
+    });
+
+    test("should render 'No description' when description is null", () => {
+        const travelWithNullDescription: Travel = { ...travel, description: null };
+        render(<TravelCard travel={travelWithNullDescription} />);
+        expect(screen.queryByText("No description")).not.toBeNull();
+    });
+
+    test("should render '0円' when amount is null", () => {
+        const travelWithNullAmount: Travel = { ...travel, amount: null };
+        render(<TravelCard travel={travelWithNullAmount} />);
+        expect(screen.queryByText("金額: 0円")).not.toBeNull();
+    });
+});

--- a/src/__tests__/Components/projects/project-detail/travel-list/travel-list.test.tsx
+++ b/src/__tests__/Components/projects/project-detail/travel-list/travel-list.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, cleanup  } from '@testing-library/react';
+import { describe, test, expect, afterEach } from "bun:test";
+import { Travel } from "@prisma/client";
+import TravelList from '@/app/Components/projects/project-detail/travel-list/travel-list';
+
+describe('TravelList', () => {
+    const travelDefaultList: Travel[] = [
+        {
+            id: "1",
+            name: "Tokyo Trip",
+            description: "A wonderful trip to Tokyo",
+            amount: 10000,
+            date: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            userId: "user1",
+            projectId: "project1",
+            categoryId: "category1",
+        },
+        {
+            id: "2",
+            name: "Kyoto Trip",
+            description: "A beautiful trip to Kyoto",
+            amount: 8000,
+            date: new Date(),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            userId: "user2",
+            projectId: "project2",
+            categoryId: "category2",
+        },
+    ];
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    test("should render travel list with travel cards", () => {
+        render(<TravelList travelDefaultList={travelDefaultList} />);
+        
+        travelDefaultList.forEach(travel => {
+            expect(screen.queryByText(travel.name)).not.toBeNull();
+        });
+
+        travelDefaultList.forEach(travel => {
+            expect(screen.queryByText(travel.description as string)).not.toBeNull();
+        });
+
+        travelDefaultList.forEach(travel => {
+            expect(screen.queryByText(`金額: ${travel.amount}円`)).not.toBeNull();
+        });
+    });
+
+    test("should update travel list when travelDefaultList prop changes", () => {
+        const { rerender } = render(<TravelList travelDefaultList={travelDefaultList} />);
+
+        const newTravelList: Travel[] = [
+            {
+                id: "3",
+                name: "Osaka Trip",
+                description: "An exciting trip to Osaka",
+                amount: 9000,
+                date: new Date(),
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                userId: "user3",
+                projectId: "project3",
+                categoryId: "category3",
+            },
+        ];
+
+        rerender(<TravelList travelDefaultList={newTravelList} />);
+        
+        newTravelList.forEach(travel => {
+            expect(screen.queryByText(travel.name)).not.toBeNull();
+        });
+
+        travelDefaultList.forEach(travel => {
+            expect(screen.queryByText(travel.name)).toBeNull();
+        });
+    });
+});

--- a/src/__tests__/Components/projects/project-detail/travel-total/travel-total.test.tsx
+++ b/src/__tests__/Components/projects/project-detail/travel-total/travel-total.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, cleanup  } from '@testing-library/react';
+import { describe, test, expect, afterEach } from "bun:test";
+import TravelTotal from '@/app/Components/projects/project-detail/travel-total/travel-total';
+
+describe('TravelTotal', () => {
+    afterEach(() => {
+        cleanup();
+    });
+
+    test("should render total amount correctly", () => {
+        const total = 123456;
+
+        render(<TravelTotal total={total} />);
+
+        expect(screen.queryByText(`合計金額: ¥${total.toLocaleString()}`)).not.toBeNull();
+    });
+
+    test("should format total amount correctly with commas", () => {
+        const total = 1234567;
+
+        render(<TravelTotal total={total} />);
+
+        expect(screen.queryByText(`合計金額: ¥${total.toLocaleString()}`)).not.toBeNull();
+    });
+
+    test("should render zero amount correctly", () => {
+        const total = 0;
+
+        render(<TravelTotal total={total} />);
+
+        expect(screen.queryByText(`合計金額: ¥${total.toLocaleString()}`)).not.toBeNull();
+    });
+
+    test("should handle large numbers correctly", () => {
+        const total = 123456789012345;
+
+        render(<TravelTotal total={total} />);
+
+        expect(screen.queryByText(`合計金額: ¥${total.toLocaleString()}`)).not.toBeNull();
+    });
+});

--- a/src/app/Components/projects/project-detail/project-detail.tsx
+++ b/src/app/Components/projects/project-detail/project-detail.tsx
@@ -2,31 +2,33 @@
 
 import { useRouter } from 'next/navigation';
 import CONSTANTS from "@/app/utils/common-constants";
+import { Travel } from "@prisma/client";
 import { useProjectDetail } from '@/app/hooks/projects/useProjectDetail';
-import { useTravelList } from '@/app/hooks/money/useTravelList';
 import { useTravelForm } from '@/app/hooks/money/useTravelForm';
+import { useTravelTotal } from '@/app/hooks/money/useTravelTotal';
 import ProjectTitle from '@/app/Components/projects/common/atoms/project-title';
 import ProjectDetailContent from '@/app/Components/projects/project-detail/project-detail-contents/project-detail-contents';
 import TravelCreateForm from '@/app/Components/projects/project-detail/travel-create-form/travel-create-form';
 import TravelList from '@/app/Components/projects/project-detail/travel-list/travel-list';
 import TravelTotal from './travel-total/travel-total';
-import { useTravelTotal } from '@/app/hooks/money/useTravelTotal';
-
 
 interface ProjectDetailProps {
     projectId: string;
     userId: string | undefined;
+    travelSCList: Travel[];
 };
 
 /**
  * プロジェクト詳細
  * @param projectId
  * @param userId
+ * @param travelSCList
  * @returns JSX
  */
 const ProjectDetail = ({
     projectId,
     userId,
+    travelSCList,
 }: ProjectDetailProps) => {
     const router = useRouter();
 
@@ -42,30 +44,21 @@ const ProjectDetail = ({
     });
 
     const {
-        travelList: travelDefaultList,
-        isLoading: travelIsLoading,
-    } = useTravelList({
-        userId: userId,
-        projectId: projectId,
-    });
-
-    const {
         form,
         onCreateSubmit,
         travelList,
     } = useTravelForm({
         userId: userId,
         projectId: projectId,
-        travelDefaultList: travelDefaultList,
+        travelDefaultList: travelSCList,
     });
 
     const {
         totalAmount,
     } = useTravelTotal({
-        travelDefaultList: travelDefaultList,
+        travelDefaultList: travelSCList,
     });
 
-    
     return (
         <div className="flex flex-col h-[90%] overflow-hidden">
             <div className="p-2 border border-pink-200">
@@ -91,7 +84,6 @@ const ProjectDetail = ({
                     <div className="flex-grow bg-white rounded-lg shadow p-3">
                         <TravelList 
                             travelDefaultList={travelList}
-                            isLoading={travelIsLoading}
                         />
                     </div>
                 </div>

--- a/src/app/Components/projects/project-detail/project-server-detail.tsx
+++ b/src/app/Components/projects/project-detail/project-server-detail.tsx
@@ -1,5 +1,9 @@
+import { Suspense } from 'react';
 import { supabaseServer } from '@/app/lib/supabase/supabase-server';
+import CONSTANTS from "@/app/utils/common-constants";
+import { Travel } from "@prisma/client";
 import ProjectDetail from '@/app/Components/projects/project-detail/project-detail';
+import ProjectDetailLoading from './project-detail-contents/atoms/project-detail-loading';
 
 interface ProjectServerDetailProps {
     projectId: string,
@@ -15,11 +19,19 @@ const ProjectServerDetail = async ({
     const supabase = supabaseServer();
     const { data: {user} } = await supabase.auth.getUser();
 
+    const res = await fetch(`${CONSTANTS.SC_TRAVEL_DATAS_URL}/${user?.id}/${projectId}`);
+    const travelSCList: Travel[] = await res.json();
+
     return (
-        <ProjectDetail
-            projectId={projectId}
-            userId={user?.id}
-        />
+        <Suspense 
+            fallback={<ProjectDetailLoading label={"Loading..."} 
+        />}>
+            <ProjectDetail
+                projectId={projectId}
+                userId={user?.id}
+                travelSCList={travelSCList} 
+            />
+        </Suspense>
     );
 }
 

--- a/src/app/Components/projects/project-detail/travel-list/molecules/travel-card.tsx
+++ b/src/app/Components/projects/project-detail/travel-list/molecules/travel-card.tsx
@@ -1,0 +1,35 @@
+import { Travel } from "@prisma/client";
+import { 
+    Card, 
+    CardContent, 
+    CardDescription, 
+    CardHeader, 
+    CardTitle 
+} from "@/components/ui/card";
+
+interface TravelCardProps {
+    travel: Travel;
+};
+
+/**
+ * 旅行カード
+ * @param travel
+ * @returns JSX
+ */
+const TravelCard = ({
+    travel,
+}: TravelCardProps) => {
+    return (
+        <Card className="w-full">
+            <CardHeader>
+                <CardTitle>{travel.name}</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <CardDescription>{travel.description || "No description"}</CardDescription>
+                <p className="mt-2 font-semibold">金額: {travel.amount !== null ? `${travel.amount}円` : "0円"}</p>
+            </CardContent>
+        </Card>
+    );
+}
+
+export default TravelCard;

--- a/src/app/Components/projects/project-detail/travel-list/travel-list.tsx
+++ b/src/app/Components/projects/project-detail/travel-list/travel-list.tsx
@@ -1,21 +1,18 @@
 import { useEffect, useState } from "react";
 import { Travel } from "@prisma/client";
-import ProjectDetailLoading from "../project-detail-contents/atoms/project-detail-loading";
+import TravelCard from "@/app/Components/projects/project-detail/travel-list/molecules/travel-card";
 
 interface TravelListProps {
     travelDefaultList: Travel[];
-    isLoading: boolean;
 };
 
 /**
  * 旅行リスト
  * @param travelDefaultList
- * @param isLoading
  * @returns JSX
  */
 const TravelList = ({
     travelDefaultList,
-    isLoading,
 }: TravelListProps) => {
     const [travelList, setTravelList] = useState<Travel[]>(travelDefaultList);
 
@@ -24,21 +21,11 @@ const TravelList = ({
     }, [travelDefaultList]);
 
     return (
-        <>
-            {isLoading ? (
-                <ProjectDetailLoading label={"Loading..."} />
-            ) : (
-                <div>
-                    {travelList.map((travel) => (
-                        <div key={travel.id}>
-                            <div>{travel.name}</div>
-                            <div>{travel.description}</div>
-                            <div>{travel.amount}</div>
-                        </div>
-                    ))}
-                </div>
-            )}
-        </>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {travelList.map((travel) => (
+                <TravelCard key={travel.id} travel={travel} />
+            ))}
+        </div>
     );
 }
 

--- a/src/app/utils/common-constants.ts
+++ b/src/app/utils/common-constants.ts
@@ -1,19 +1,20 @@
-
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+const CC_BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+const SC_BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3001';
 
 const CONSTANTS = {
-    BACKEND_URL,
+    CC_BACKEND_URL,
+    SC_BACKEND_URL,
 
     /** ${BACKEND_URL}/projects */
-    PROJECT_DATAS_URL: `${BACKEND_URL}/projects`,
+    PROJECT_DATAS_URL: `${CC_BACKEND_URL}/projects`,
     /** ${BACKEND_URL}/project/user/:userId */
-    GET_PROJECT_DATAS_BY_USER_ID_URL: `${BACKEND_URL}/projects/user`,
+    GET_PROJECT_DATAS_BY_USER_ID_URL: `${CC_BACKEND_URL}/projects/user`,
     /** ${BACKEND_URL}/project/:projectId */
-    GET_PROJECT_DATAS_BY_PROJECT_ID_URL: `${BACKEND_URL}/projects`,
+    GET_PROJECT_DATAS_BY_PROJECT_ID_URL: `${CC_BACKEND_URL}/projects`,
 
     /** ${BACKEND_URL}/travels */
-    TRAVEL_DATAS_URL: `${BACKEND_URL}/travels`,
+    TRAVEL_DATAS_URL: `${CC_BACKEND_URL}/travels`,
+    SC_TRAVEL_DATAS_URL: `${SC_BACKEND_URL}/travels`,
 
     /** /auth/signin */
     AUTH_SIGNIN: '/auth/signin',

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
以下変更。
・旅行データをサーバーコンポーネント上で取得する方法に変更。

※今まではデータ取得をクライアントコンポーネントで実施していた。
    しかし、セキュリティの観点からなるべくサーバーコンポーネントで取得し、
    クライアントコンポーネントに渡してよいデータに加工するような実装に変更していきたい。
    そのきっかけとして今回対応を実施。