### PR TITLE
プロジェクト詳細データの取得方法変更

### DIFF
--- a/src/__tests__/Components/projects/common/atoms/project-loading.test.tsx
+++ b/src/__tests__/Components/projects/common/atoms/project-loading.test.tsx
@@ -1,17 +1,17 @@
 /* eslint-disable no-undef */
 import React from 'react';
 import { render, screen, cleanup } from '@testing-library/react';
-import ProjectDetailLoading from '@/app/Components/projects/project-detail/project-detail-contents/atoms/project-detail-loading';
+import ProjectLoading from '@/app/Components/projects/common/atoms/project-loading';
 
 describe('ProjectDetailLoading', () => {
     afterEach(() => {
         cleanup();
     });
 
-    test('renders the project detail label', () => {
+    test('renders the project label', () => {
         const labelText = 'My Project';
 
-        render(<ProjectDetailLoading label={labelText} />);
+        render(<ProjectLoading label={labelText} />);
 
         const labelElement = screen.getByText(labelText);
 
@@ -20,7 +20,7 @@ describe('ProjectDetailLoading', () => {
     });
 
     test('renders without label', () => {
-        render(<ProjectDetailLoading label="" />);
+        render(<ProjectLoading label="" />);
         const labelElement = document.querySelector(
             '.text-2xl.font-bold.text-gray-400'
         );
@@ -30,9 +30,9 @@ describe('ProjectDetailLoading', () => {
         }
     });
 
-    test('renders long project detail label', () => {
+    test('renders long project label', () => {
         const longLabel = 'A'.repeat(100);
-        render(<ProjectDetailLoading label={longLabel} />);
+        render(<ProjectLoading label={longLabel} />);
         const labelElement = screen.getByText(longLabel);
         expect(labelElement).not.toBeNull();
         expect(labelElement.tagName.toLowerCase()).toBe('div');
@@ -40,7 +40,7 @@ describe('ProjectDetailLoading', () => {
 
     test('applies correct CSS classes', () => {
         const labelText = 'My Project';
-        render(<ProjectDetailLoading label={labelText} />);
+        render(<ProjectLoading label={labelText} />);
         const labelElement = screen.getByText(labelText);
 
         // クラスリストを手動で確認

--- a/src/__tests__/Components/projects/project-detail/project-detail-contents/project-detail-contents.test.tsx
+++ b/src/__tests__/Components/projects/project-detail/project-detail-contents/project-detail-contents.test.tsx
@@ -11,7 +11,7 @@ describe('ProjectDetailContent', () => {
     test('renders the project detail label', () => {
         const desc = 'My Project';
 
-        render(<ProjectDetailContent description={desc} isLoading={false} />);
+        render(<ProjectDetailContent description={desc} />);
 
         const labelElement = screen.getByText(desc);
 
@@ -23,7 +23,7 @@ describe('ProjectDetailContent', () => {
     test('renders the project detail label empty', () => {
         const desc = '';
 
-        render(<ProjectDetailContent description={desc} isLoading={false} />);
+        render(<ProjectDetailContent description={desc} />);
 
         const labelElement = screen.getByText((content, element) => {
             return (
@@ -39,16 +39,5 @@ describe('ProjectDetailContent', () => {
             expect(labelElement.tagName.toLowerCase()).toBe('div');
             expect(labelElement.className).toContain('text-gray-400');
         }
-    });
-
-    test('renders the project loading', () => {
-        const loadingLabel = 'Loading...';
-
-        render(<ProjectDetailContent description={''} isLoading={true} />);
-
-        const labelElement = screen.getByText(loadingLabel);
-
-        expect(labelElement).not.toBeNull();
-        expect(labelElement?.tagName.toLowerCase()).toBe('div');
     });
 });

--- a/src/app/Components/projects/common/atoms/project-loading.tsx
+++ b/src/app/Components/projects/common/atoms/project-loading.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
 
-interface ProjectDetailLoadingProps {
+interface ProjectLoadingProps {
     label: string;
 }
 
 /**
- * プロジェクト詳細ローディング
+ * プロジェクトローディング
  * @param label
  * @returns JSX
  */
-const ProjectDetailLoading = ({ label }: ProjectDetailLoadingProps) => {
+const ProjectLoading = ({ label }: ProjectLoadingProps) => {
     return (
         <div className="flex items-center justify-center h-full">
             <div className="text-2xl font-bold text-gray-400">{label}</div>
@@ -17,4 +17,4 @@ const ProjectDetailLoading = ({ label }: ProjectDetailLoadingProps) => {
     );
 };
 
-export default ProjectDetailLoading;
+export default ProjectLoading;

--- a/src/app/Components/projects/project-detail/project-detail-contents/project-detail-contents.tsx
+++ b/src/app/Components/projects/project-detail/project-detail-contents/project-detail-contents.tsx
@@ -1,30 +1,20 @@
 import React from 'react';
-import ProjectDetailLoading from '@/app/Components/projects/project-detail/project-detail-contents/atoms/project-detail-loading';
 
 interface ProjectDetailContentProps {
-    isLoading: boolean;
     description: string;
 }
 
 /**
  * プロジェクト詳細コンテンツ
- * @param isLoading
  * @param description
  * @returns JSX
  */
-const ProjectDetailContent = ({
-    isLoading,
-    description,
-}: ProjectDetailContentProps) => {
+const ProjectDetailContent = ({ description }: ProjectDetailContentProps) => {
     return (
         <div className="h-full">
-            {isLoading ? (
-                <ProjectDetailLoading label={'Loading...'} />
-            ) : (
-                <div className="p-6">
-                    <div className="text-sm text-gray-400">{description}</div>
-                </div>
-            )}
+            <div className="p-6">
+                <div className="text-sm text-gray-400">{description}</div>
+            </div>
         </div>
     );
 };

--- a/src/app/Components/projects/project-detail/project-detail.tsx
+++ b/src/app/Components/projects/project-detail/project-detail.tsx
@@ -2,11 +2,10 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
-import CONSTANTS from '@/app/utils/common-constants';
-import { Travel } from '@prisma/client';
 import Modal from 'react-modal';
+import CONSTANTS from '@/app/utils/common-constants';
+import { Project, Travel } from '@prisma/client';
 
-import { useProjectDetail } from '@/app/hooks/projects/useProjectDetail';
 import { useTravelForm } from '@/app/hooks/travels/useTravelForm';
 import { useTravelTotal } from '@/app/hooks/travels/useTravelTotal';
 
@@ -22,6 +21,7 @@ interface ProjectDetailProps {
     projectId: string;
     userId: string | undefined;
     travelSCList: Travel[];
+    SCProject: Project;
 }
 
 /**
@@ -29,22 +29,20 @@ interface ProjectDetailProps {
  * @param projectId
  * @param userId
  * @param travelSCList
+ * @param SCProject
  * @returns JSX
  */
 const ProjectDetail = ({
     projectId,
     userId,
     travelSCList,
+    SCProject,
 }: ProjectDetailProps) => {
     const router = useRouter();
 
     if (userId === undefined) {
         router.push(CONSTANTS.AUTH_SIGNIN);
     }
-
-    const { project, isLoading } = useProjectDetail({
-        projectId: projectId,
-    });
 
     const {
         travelList,
@@ -75,16 +73,15 @@ const ProjectDetail = ({
     return (
         <div className="flex flex-col h-[90%] overflow-hidden">
             <div className="p-2 border border-pink-200">
-                <ProjectTitle title={project?.name ?? 'Non Title'} />
+                <ProjectTitle title={SCProject?.name ?? 'Non Title'} />
             </div>
 
             <div className="flex-1 overflow-y-auto">
                 <div className="flex flex-col p-4 space-y-4">
                     <div className="flex-grow bg-white rounded-lg shadow p-3">
                         <ProjectDetailContent
-                            isLoading={isLoading}
                             description={
-                                project?.description ?? 'Non Description'
+                                SCProject?.description ?? 'Non Description'
                             }
                         />
                     </div>

--- a/src/app/Components/projects/project-detail/project-server-detail.tsx
+++ b/src/app/Components/projects/project-detail/project-server-detail.tsx
@@ -1,9 +1,10 @@
 import { Suspense } from 'react';
 import { supabaseServer } from '@/app/lib/supabase/supabase-server';
 import CONSTANTS from '@/app/utils/common-constants';
-import { Travel } from '@prisma/client';
+import { Project, Travel } from '@prisma/client';
+
 import ProjectDetail from '@/app/Components/projects/project-detail/project-detail';
-import ProjectDetailLoading from './project-detail-contents/atoms/project-detail-loading';
+import ProjectLoadingProps from '@/app/Components/projects/common/atoms/project-loading';
 
 interface ProjectServerDetailProps {
     projectId: string;
@@ -19,17 +20,23 @@ const ProjectServerDetail = async ({ projectId }: ProjectServerDetailProps) => {
         data: { user },
     } = await supabase.auth.getUser();
 
-    const res = await fetch(
+    const resGetTravelList = await fetch(
         `${CONSTANTS.SC_TRAVEL_DATAS_URL}/${user?.id}/${projectId}`
     );
-    const travelSCList: Travel[] = await res.json();
+    const travelSCList: Travel[] = await resGetTravelList.json();
+
+    const resGetProject = await fetch(
+        `${CONSTANTS.SC_PROJECT_DATAS_URL}/${projectId}`
+    );
+    const SCProject: Project = await resGetProject.json();
 
     return (
-        <Suspense fallback={<ProjectDetailLoading label={'Loading...'} />}>
+        <Suspense fallback={<ProjectLoadingProps label={'Loading...'} />}>
             <ProjectDetail
                 projectId={projectId}
                 userId={user?.id}
                 travelSCList={travelSCList}
+                SCProject={SCProject}
             />
         </Suspense>
     );

--- a/src/app/utils/common-constants.ts
+++ b/src/app/utils/common-constants.ts
@@ -8,6 +8,8 @@ const CONSTANTS = {
 
     /** ${BACKEND_URL}/projects */
     PROJECT_DATAS_URL: `${CC_BACKEND_URL}/projects`,
+    SC_PROJECT_DATAS_URL: `${SC_BACKEND_URL}/projects`,
+
     /** ${BACKEND_URL}/project/user/:userId */
     GET_PROJECT_DATAS_BY_USER_ID_URL: `${CC_BACKEND_URL}/projects/user`,
     /** ${BACKEND_URL}/project/:projectId */


### PR DESCRIPTION
プロジェクト詳細データをクライアントコンポーネント上で取得してました。
セキュリティ上の観点からサーバーコンポーネント上で取得するように変更しました。